### PR TITLE
chore(release): publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,7 @@ jobs:
           SEMANTIC_RELEASE_PACKAGE: ${{ github.event.repository.name }}
         with:
           extra_plugins: |
+            @semantic-release/commit-analyzer
             @semantic-release/changelog
             @semantic-release/exec
             @semantic-release/git


### PR DESCRIPTION
adding `@semantic-release/commit-analyzer` even though it should not be needed — https://github.com/stacks-network/jsontokens-js/runs/6628758986?check_suite_focus=true